### PR TITLE
Magnetization expectation value should be the net value

### DIFF
--- a/tutorials/general/quantum_ising/quantum_ising.ipynb
+++ b/tutorials/general/quantum_ising/quantum_ising.ipynb
@@ -2355,9 +2355,9 @@
     "            bstate_M += (state[i]^2 * (spin ? 1 : -1))/N\n",
     "        end\n",
     "        @assert abs(bstate_M) <= 1\n",
-    "        M += abs(bstate_M)\n",
+    "        M += bstate_M\n",
     "    end\n",
-    "    return M\n",
+    "    return abs(M)\n",
     "end"
    ]
   },


### PR DESCRIPTION
Magnetization is directional, and thus when calculating its expectation value, we shouldn't call `abs`. We could, however, call `abs` on the final expectation value if we want.